### PR TITLE
Implement a proper distilled page ("dpage")

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -9,8 +9,6 @@ type ApiResponse<T> = {
 };
 
 export type GetBookListResponse = {
-  json?: unknown[];
-  html?: string;
   browserId?: string;
   pageId?: string;
 };

--- a/src/components/GoodreadsConnectionModal.tsx
+++ b/src/components/GoodreadsConnectionModal.tsx
@@ -29,11 +29,6 @@ export function GoodreadsConnectionModal(props: GoodreadsConnectionModalProps) {
   const startedBrowserPageRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!bookListData.html) return;
-    callbacksRef.current.onProgressStep?.(2);
-  }, [bookListData.html]);
-
-  useEffect(() => {
     const browserId = bookListData.browserId;
     const pageId = bookListData.pageId;
     if (!browserId || !pageId) return;
@@ -55,7 +50,7 @@ export function GoodreadsConnectionModal(props: GoodreadsConnectionModalProps) {
             if (pollResult?.status === 'SUCCESS') {
               break;
             }
-            await new Promise((resolve) => setTimeout(resolve, 5000));
+            await new Promise((resolve) => setTimeout(resolve, 3000));
           } catch (error) {
             if (isStale()) return;
             Sentry.captureException(error, { tags: SENTRY_TAGS });
@@ -96,7 +91,8 @@ export function GoodreadsConnectionModal(props: GoodreadsConnectionModalProps) {
     };
   }, [bookListData.browserId, bookListData.pageId]);
 
-  const iframeContent = bookListData.html;
+  const { browserId, pageId } = bookListData;
+  if (!browserId || !pageId) return;
 
   return (
     <Modal
@@ -114,7 +110,7 @@ export function GoodreadsConnectionModal(props: GoodreadsConnectionModalProps) {
     >
       <div className="relative pt-5">
         <iframe
-          srcDoc={iframeContent}
+          src={`/api/dpage/${browserId}/${pageId}`}
           sandbox="allow-same-origin allow-scripts allow-forms"
           className="w-full h-[380px] rounded-xl border border-gray-200"
         />

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,22 @@ const __dirname = path.dirname(__filename);
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+const SPINNER_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Loading</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <div>
+      <span class="spinner" aria-label="Loading" style="border-top-color: #333"></span>
+      <span>Loading...</span>
+    </div>
+  </body>
+</html>`;
+
 function formatDistilledPage(
   html: string,
   sessionId: string,
@@ -61,19 +77,7 @@ function formatDistilledPage(
 
   const form = document.createElement('form');
   form.setAttribute('method', 'POST');
-  form.setAttribute('action', '/api/get-book-list');
-
-  const idInput = document.createElement('input');
-  idInput.setAttribute('type', 'hidden');
-  idInput.setAttribute('name', 'id');
-  idInput.setAttribute('value', sessionId);
-  form.appendChild(idInput);
-
-  const pageIdInput = document.createElement('input');
-  pageIdInput.setAttribute('type', 'hidden');
-  pageIdInput.setAttribute('name', 'pageId');
-  pageIdInput.setAttribute('value', pageId);
-  form.appendChild(pageIdInput);
+  form.setAttribute('action', `/api/dpage/${sessionId}/${pageId}`);
 
   const body = document.body;
   while (body.firstChild) {
@@ -180,75 +184,98 @@ async function initiateDistill(
 }
 
 app.post('/api/get-book-list', async (req, res) => {
-  const body = (req.body ?? {}) as Record<string, unknown>;
-
-  let sessionId: string | undefined;
-  let pageId: string | undefined;
-  const fields: Record<string, string> = {};
-
-  for (const [key, value] of Object.entries(body)) {
-    if (value === undefined || value === null) continue;
-    const stringValue = typeof value === 'string' ? value : String(value);
-    if (key === 'id' || key === 'sessionId') {
-      sessionId = stringValue;
-    } else if (key === 'pageId') {
-      pageId = stringValue;
-    } else {
-      fields[key] = stringValue;
-    }
-  }
-
-  if (!sessionId) {
-    sessionId = req.sessionID;
-  }
-
-  if (!sessionId) {
-    return res.status(503).send();
-  }
-
-  Logger.info('get-book-list resolved ids', { sessionId, pageId });
+  const sessionId = req.sessionID!;
 
   try {
-    let browserId = sessionId;
-    let resolvedPageId: string;
+    const headers = await getImportantHeaders(req);
+    const { browserId, pageId } = await prepareNewBrowser(sessionId, headers);
+    await navigatePage(browserId, pageId, GOODREADS_REVIEW_LIST_URL);
 
-    if (!pageId) {
-      const headers = await getImportantHeaders(req);
-      const prepared = await prepareNewBrowser(sessionId, headers);
-      browserId = prepared.browserId;
-      resolvedPageId = prepared.pageId;
-      await navigatePage(browserId, resolvedPageId, GOODREADS_REVIEW_LIST_URL);
-    } else {
-      resolvedPageId = pageId;
+    const { html } = await initiateDistill(browserId, pageId);
+    if (!html) {
+      return res.status(500).send();
     }
-
-    const { json, html } = await initiateDistill(
+    const responseData = {
       browserId,
-      resolvedPageId,
-      fields
-    );
-
-    const responseData: Record<string, unknown> = {
-      browserId,
-      pageId: resolvedPageId,
+      pageId,
+      html: formatDistilledPage(html, sessionId, pageId),
     };
-    if (json !== undefined) {
-      responseData.json = json;
-    }
-    if (html) {
-      responseData.html = formatDistilledPage(
-        html,
-        req.sessionID,
-        resolvedPageId
-      );
-    }
-
     return res.json({
       success: true,
       data: responseData,
     });
   } catch (error) {
-    Logger.error('get-book-list handler failed', error as Error, { sessionId, pageId });
+    Logger.error('get-book-list handler failed', error as Error, { sessionId });
+    return res.status(500).send();
+  }
+});
+
+// Since the browser can't redirect from GET to POST,
+// use an auto-submit form to do that.
+function redirect(action: string): string {
+  return `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <link rel="stylesheet" href="/style.css" />
+    </head>
+    <body>
+      <form id="redirect" action="${action}" method="post">
+      </form>
+      <div>
+        <span class="spinner" aria-label="Loading" style="border-top-color: #333"></span>
+        <span>Loading...</span>
+      </div>
+      <script>setTimeout(() => document.getElementById('redirect').submit(), 5000);</script>
+    </body>
+    </html>`;
+}
+
+app.get('/api/dpage/:browserId/:pageId', (req, res) => {
+  const { browserId, pageId } = req.params;
+  if (!browserId || !pageId) {
+    return res.status(503).send();
+  }
+  return res
+    .type('text/html')
+    .send(redirect(`/api/dpage/${browserId}/${pageId}`));
+});
+
+app.post('/api/dpage/:browserId/:pageId', async (req, res) => {
+  const browserId = req.params.browserId;
+  const pageId = req.params.pageId;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const fields: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(body)) {
+    if (value === undefined || value === null) continue;
+    fields[key] = typeof value === 'string' ? value : String(value);
+  }
+
+  if (!browserId || !pageId) {
+    return res.status(503).send();
+  }
+
+  try {
+    const { json, html } = await initiateDistill(browserId, pageId, fields);
+
+    if (html) {
+      const formattedHtml = formatDistilledPage(html, req.sessionID, pageId);
+      return res.type('text/html').send(formattedHtml);
+    }
+
+    if (json) {
+      // The data is ready, show the loading spinner until
+      // poll-browser grabs it
+      Logger.info('Distillation completed. Data is available!', { json });
+      return res.type('text/html').send(SPINNER_HTML);
+    }
+
+    return res.status(500).send();
+  } catch (error) {
+    Logger.error('dpage handler failed', error as Error, { browserId, pageId });
     return res.status(500).send();
   }
 });


### PR DESCRIPTION
This is a follow-up to PR #32 and addresses issues such as handling an incorrect password.

In addition, the loading state is now indicated by a spinner instead of a blank page, which can be confusing.

To verify, launch Remote Browser first and then Page Turner pointing to it. Sign in as usual but deliberately enter an incorrect password. The sign-in page should reappear with the error message.

<img width="1399" height="1213" alt="image" src="https://github.com/user-attachments/assets/80c727e6-bc38-4fb1-83b4-74ac0f46342d" />
