### PR TITLE
Rename mcp-session-id to session-id

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -115,7 +115,7 @@ app.use(express.urlencoded({ extended: true }));
 function readSessionIdFromCookie(req: express.Request): string | undefined {
   const cookieHeader = req.headers['cookie'];
   if (!cookieHeader) return undefined;
-  const match = cookieHeader.match(/(?:^|; )mcp-session-id=([^;]+)/);
+  const match = cookieHeader.match(/(?:^|; )session-id=([^;]+)/);
   return match ? decodeURIComponent(match[1]) : undefined;
 }
 
@@ -124,17 +124,17 @@ function requireSession(
   res: express.Response,
   next: express.NextFunction
 ): void {
-  const headerValue = req.headers['x-mcp-session-id'];
+  const headerValue = req.headers['x-session-id'];
   const headerSessionId = Array.isArray(headerValue)
     ? headerValue[0]
     : headerValue;
   const sessionId = headerSessionId || readSessionIdFromCookie(req);
   if (!sessionId) {
-    res.status(400).json({ error: 'mcp-session-id is required' });
+    res.status(400).json({ error: 'session-id is required' });
     return;
   }
   req.sessionID = sessionId;
-  Sentry.getIsolationScope().setTag('mcp_session_id', sessionId);
+  Sentry.getIsolationScope().setTag('session_id', sessionId);
   next();
 }
 

--- a/src/server/instrument.ts
+++ b/src/server/instrument.ts
@@ -80,10 +80,10 @@ if (settings.SENTRY_DSN) {
       if (tags?.signin_id) {
         event.tags = { ...event.tags, signin_id: tags.signin_id as string };
       }
-      if (tags?.mcp_session_id) {
+      if (tags?.session_id) {
         event.tags = {
           ...event.tags,
-          mcp_session_id: tags.mcp_session_id as string,
+          session_id: tags.session_id as string,
         };
       }
 
@@ -107,10 +107,10 @@ if (settings.SENTRY_DSN) {
       if (tags?.signin_id) {
         event.tags = { ...event.tags, signin_id: tags.signin_id as string };
       }
-      if (tags?.mcp_session_id) {
+      if (tags?.session_id) {
         event.tags = {
           ...event.tags,
-          mcp_session_id: tags.mcp_session_id as string,
+          session_id: tags.session_id as string,
         };
       }
 

--- a/src/sessionContext.ts
+++ b/src/sessionContext.ts
@@ -1,9 +1,9 @@
-const COOKIE_NAME = 'mcp-session-id';
+const COOKIE_NAME = 'session-id';
 
 document.cookie = `${COOKIE_NAME}=; path=/; max-age=0; SameSite=Lax`;
 
 export function getSessionId(): string | null {
-  const match = document.cookie.match(/(?:^|; )mcp-session-id=([^;]+)/);
+  const match = document.cookie.match(/(?:^|; )session-id=([^;]+)/);
   return match ? decodeURIComponent(match[1]) : null;
 }
 
@@ -15,5 +15,5 @@ export function resetSession(): string {
 
 export function getSessionHeaders(): Record<string, string> {
   const id = getSessionId();
-  return id ? { 'x-mcp-session-id': id } : {};
+  return id ? { 'x-session-id': id } : {};
 }


### PR DESCRIPTION
The MCP session identifier was the only identity token on `/api` routes. Now that the surface is REST-only, drop the misleading `mcp` prefix from the cookie, header, and Sentry tag. Behavior is unchanged.