### PR TITLE
Actually delete the remote browser on finalize

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { trace } from '@opentelemetry/api';
 import './server/instrument.js';
 import { getClientIp, getLocation } from './server/locationService.js';
 import {
+  deleteBrowser,
   distillPage,
   getDistilledHtml,
   getDistilledJson,
@@ -364,6 +365,7 @@ app.post('/api/finalize-browser', async (req, res) => {
     }
 
     span?.setAttribute('pageturner.browser_id', browser_id);
+    await deleteBrowser(browser_id);
     Logger.info('Browser finalized', { browser_id, page_id });
 
     res.json({

--- a/src/server/remotebrowser.ts
+++ b/src/server/remotebrowser.ts
@@ -181,9 +181,17 @@ export async function getDistilledHtml(
 
 export async function deleteBrowser(browserId: string): Promise<void> {
   try {
-    await fetch(buildUrl(`/api/v1/browsers/${browserId}`), {
+    const res = await fetch(buildUrl(`/api/v1/browsers/${browserId}`), {
       method: 'DELETE',
     });
+    if (!res.ok) {
+      const errorBody = await res.text().catch(() => '');
+      Logger.warn('Failed to delete browser', {
+        browserId,
+        status: res.status,
+        body: errorBody,
+      });
+    }
   } catch (error) {
     Logger.warn('Failed to delete browser', {
       browserId,


### PR DESCRIPTION
The `/api/finalize-browser` endpoint logged Browser finalized but never invoked the remote browser's delete API. Also log a warning when the delete request returns a non-2xx response.